### PR TITLE
Remove dmraid and kpartx-boot

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -28,7 +28,6 @@ Depends:
   grub2-common,
   iso-codes,
   kpartx,
-  kpartx-boot,
   libudev1,
   locales,
   lvm2,

--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,6 @@ Depends:
   coreutils,
   cryptsetup,
   dmsetup,
-  dmraid,
   dosfstools,
   e2fsprogs,
   f2fs-tools,


### PR DESCRIPTION
They were removed from Ubuntu https://bugs.launchpad.net/ubuntu/+source/dmraid/+bug/2073677 and are likely no longer needed for encrypted installs (please test!)

After merge, master_resolute can be removed

Related to https://github.com/pop-os/distinst/pull/349